### PR TITLE
Remove themeLabel from theme codes

### DIFF
--- a/src/components/ThemeItem/index.js
+++ b/src/components/ThemeItem/index.js
@@ -182,7 +182,7 @@ const ThemeItem = (props) => {
   const textColor = props.theme.text_color
   const activePresence = props.theme.active_presence
   const mentionBadge = props.theme.mention_badge
-  const copyString = `${props.themeLabel ? themeName + ' -- ' : ''}${columnBg},#121016,${activeItem},${activeItemText},${hoverItem},${textColor},${activePresence},${mentionBadge},${topNavBg},${topNavText}`
+  const copyString = `${columnBg},#121016,${activeItem},${activeItemText},${hoverItem},${textColor},${activePresence},${mentionBadge},${topNavBg},${topNavText}`
   const likes = props.theme.likes
 
   const updateLike = () => {


### PR DESCRIPTION
This PR resolves issue #62, ensuring that the user can simply copy and paste the theme codes into Slack, without needing to manually remove each themeLabel from the string first.

Currently, users copy content formatted like this to their clipboard: 

```
Material Ocean -- 
#0f111a,#121016,#0f111a,#82aaff,#1b1e2d,#dadada,#c3e88d,#c792ea,#0f111a,#dadada
```

With this PR, content will be copied like this:

```
#0f111a,#121016,#0f111a,#82aaff,#1b1e2d,#dadada,#c3e88d,#c792ea,#0f111a,#dadada
```